### PR TITLE
adjust default for erf

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ which results in
         ],
         "erf": [
             {
-                "x": 0.95,
+                "x": 0.10,
                 "y": 0.047619047619047616
             }
         ]
@@ -378,7 +378,7 @@ values.
 |---|---|---|---|
 | `recall` | Labels | Recall | 0.1, 0.25, 0.5, 0.75, 0.9 |
 | `wss` | Recall | Work Saved over Sampling at recall | 0.95 |
-| `erf` | Labels | ERF | 0.95 |
+| `erf` | Labels | ERF | 0.10 |
 
 
 ### Override default values

--- a/asreviewcontrib/insights/entrypoint.py
+++ b/asreviewcontrib/insights/entrypoint.py
@@ -126,7 +126,7 @@ class StatsEntryPoint(BaseEntryPoint):
                             metavar='erf',
                             type=float,
                             nargs='+',
-                            default=[0.95],
+                            default=[0.10],
                             help='A (list of) values to compute the erf at.')
         parser.add_argument('--priors', action='store_true',
                             help='Include records used as prior knowledge '

--- a/asreviewcontrib/insights/stats.py
+++ b/asreviewcontrib/insights/stats.py
@@ -8,7 +8,7 @@ from asreviewcontrib.insights.metrics import _wss
 def get_stats(state_obj,
               recall=[0.1, 0.25, 0.5, 0.75, 0.9],
               wss=[0.95],
-              erf=[0.95],
+              erf=[0.10],
               priors=False,
               x_absolute=False,
               y_absolute=False):


### PR DESCRIPTION
This PR proposes to adjust the default setting for the erf in the output. The proportion of extra relevant records found at .95 recall might be less informative than knowing this earlier in the process, for example at .10. 