### PR TITLE
Add TD and ATD metrics to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,42 @@ which results in
                         0.9047619047619048
                     ]
                 ]
+            },
+            {
+                "id": "atd",
+                "title": "Average time to discovery",
+                "value": 101.71428571428571
+            },
+            {
+                "id": "td",
+                "title": "Time to discovery",
+                "value": [
+                    [
+                        3898,
+                        22
+                    ],
+                    [
+                        284,
+                        23
+                    ],
+                    [
+                        592,
+                        25
+                    ],
+                    ...
+                    [
+                        2382,
+                        184
+                    ],
+                    [
+                        5479,
+                        224
+                    ],
+                    [
+                        3316,
+                        575
+                    ]
+                ]
             }
         ]
     }
@@ -405,6 +441,8 @@ is the results of the metric. Some metrics are computed for multiple values.
 | `recall` | Labels | Recall | 0.1, 0.25, 0.5, 0.75, 0.9 |
 | `wss` | Recall | Work Saved over Sampling at recall | 0.95 |
 | `erf` | Labels | ERF | 0.10 |
+| `atd` | Average time to discovery (in label actions) | - | - |
+| `td` | Row number (starting at 0) | Number of records labeled | - |
 
 
 ### Override default values
@@ -469,6 +507,42 @@ asreview metrics sim_van_de_schoot_2017.asreview --wss 0.9 0.95
                     [
                         0.1,
                         0.9047619047619048
+                    ]
+                ]
+            },
+            {
+                "id": "atd",
+                "title": "Average time to discovery",
+                "value": 101.71428571428571
+            },
+            {
+                "id": "td",
+                "title": "Time to discovery",
+                "value": [
+                    [
+                        3898,
+                        22
+                    ],
+                    [
+                        284,
+                        23
+                    ],
+                    [
+                        592,
+                        25
+                    ],
+                    ...
+                    [
+                        2382,
+                        184
+                    ],
+                    [
+                        5479,
+                        224
+                    ],
+                    [
+                        3316,
+                        575
                     ]
                 ]
             }

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_almost_equal
 
 from asreviewcontrib.insights.metrics import _recall
 from asreviewcontrib.insights.metrics import recall
+from asreviewcontrib.insights.metrics import _time_to_discovery
 
 TEST_ASREVIEW_FILES = Path(Path(__file__).parent, "asreview_files")
 
@@ -75,6 +76,14 @@ def test_metric_recall_invalid_values_max():
 
     r = _recall(labels, 1.2)
     assert_almost_equal(r, 1)
+
+
+def test_time_to_disc():
+
+    labels = [1, 1, 0, 1]
+    td = _time_to_discovery([3, 2, 0, 1], labels)
+
+    assert td == [(3, 1), (2, 2), (1, 4)]
 
 
 def test_metric_recall():


### PR DESCRIPTION
This PR proposes an implementation of time to discovery and average time to discovery. The output is presented in a similar fashion as the metrics. 

Documentation might need to be extended. Maintainers, feel free to push to this branch. 