### PR TITLE
Fix WSS calculation

### DIFF
--- a/asreviewcontrib/insights/algorithms.py
+++ b/asreviewcontrib/insights/algorithms.py
@@ -24,12 +24,11 @@ def _wss_values(labels, x_absolute=False, y_absolute=False):
     n_pos_docs = sum(labels)
 
     docs_found = np.cumsum(labels)
-    docs_found_random = np.round(np.linspace(0, n_pos_docs, n_docs))
 
-    # Get the first occurrence of 1, 2, 3, ..., n_pos_docs in both arrays.
+    # Get the first occurrence of 1, 2, 3, ..., n_pos_docs in the array
     when_found = np.searchsorted(docs_found, np.arange(1, n_pos_docs + 1))
-    when_found_random = np.searchsorted(docs_found_random,
-                                        np.arange(1, n_pos_docs + 1))
+    # Find first occurence of 1, 2, 3, ..., n_pos_docs if the documents were reviewed randomly
+    when_found_random = np.ceil(np.arange(1, n_pos_docs + 1) / n_pos_docs * n_docs)
     n_found_earlier = when_found_random - when_found
 
     x = np.arange(1, n_pos_docs + 1)


### PR DESCRIPTION
WSS is defined as work over sampling and so ASReview's results should be compared to what a random sampling gives. In a random ordering of the papers to be reviewed, it is expected that to get, say, 95% of relevant papers, you should scan 95% of ALL papers. That is why the calculation to find where to get x relevant papers is x / n_pos_docs * n_docs. 

The solution currently implemented is inaccurate due to the rounding. 0 and the last value (n_pos_docs) will be represented about half as much as every other value in the docs_found_random array. For example, if we had 49 total records, and 7 relevant records, we would expect to see 1 relevant record every 7 records. However, using np.linspace and then rounding would tell us that we see the first record at record number 5, not record number 7. After that, the other numbers are still correctly even spaced (2 is then at 12, 3 is at 19, and so on), but everything is off because of what happens at the boundaries.

To my knowledge, WSS is introduced in the paper https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1447545/ (equation 4), and that supports this fix.