### PR TITLE
Fix priors bug in pad_simulation_labels

### DIFF
--- a/asreviewcontrib/insights/utils.py
+++ b/asreviewcontrib/insights/utils.py
@@ -8,7 +8,7 @@ def pad_simulation_labels(state_obj, priors=False):
 
     # get the labels
     labels = state_obj.get_labels(priors=priors).to_list()
-    
+
     if not priors:
         n_used_records = n_records - state_obj.n_priors
     else:

--- a/asreviewcontrib/insights/utils.py
+++ b/asreviewcontrib/insights/utils.py
@@ -8,10 +8,15 @@ def pad_simulation_labels(state_obj, priors=False):
 
     # get the labels
     labels = state_obj.get_labels(priors=priors).to_list()
+    
+    if not priors:
+        n_used_records = n_records - state_obj.n_priors
+    else:
+        n_used_records = n_records
 
     # if less labels than records, check if all labels available
-    if len(labels) < n_records:
+    if len(labels) < n_used_records:
 
-        labels = labels + np.zeros(n_records - len(labels)).tolist()
+        labels = labels + np.zeros(n_used_records - len(labels)).tolist()
 
     return labels


### PR DESCRIPTION
The pad_simulation_labels functions added too many zeroes if the priors are not used.