### PR TITLE
Make asreview-insights compatible with asreview version 2 

### DIFF
--- a/asreviewcontrib/insights/algorithms.py
+++ b/asreviewcontrib/insights/algorithms.py
@@ -44,9 +44,11 @@ def _loss_value(labels):
     #    This simplifies to the hyperbolic paraboloid Ny * (Nx - Ny), which is
     #    the denominator in our normalized loss.
     #
-    # Finally, we compute the normalized loss as: 
+    # Finally, we compute the normalized loss as:
     # (optimal - actual) / (optimal - worst).
-    return float((Ny * (Nx - (Ny - 1) / 2) - np.cumsum(labels).sum()) / (Ny * (Nx - Ny)))  # noqa: E501
+    return float(
+        (Ny * (Nx - (Ny - 1) / 2) - np.cumsum(labels).sum()) / (Ny * (Nx - Ny))
+    )  # noqa: E501
 
 
 def _wss_values(labels, x_absolute=False, y_absolute=False):

--- a/asreviewcontrib/insights/entrypoint.py
+++ b/asreviewcontrib/insights/entrypoint.py
@@ -1,6 +1,5 @@
 import argparse
 import json
-from pathlib import Path
 
 import matplotlib.pyplot as plt
 from asreview import open_state
@@ -11,7 +10,6 @@ from asreviewcontrib.insights import plot_recall
 from asreviewcontrib.insights import plot_wss
 from asreviewcontrib.insights.metrics import get_metrics
 from asreviewcontrib.insights.metrics import print_metrics
-from asreviewcontrib.insights.utils import _iter_states
 
 TYPE_TO_FUNC = {"recall": plot_recall, "wss": plot_wss, "erf": plot_erf}
 
@@ -83,17 +81,13 @@ class PlotEntryPoint(BaseEntryPoint):
         fig, ax = plt.subplots()
         plot_func = TYPE_TO_FUNC[args.plot_type]
         show_legend = False if len(args.asreview_files) == 1 else True
-        state_obj = _iter_states(args.asreview_files)
-        legend_values = [Path(fp).stem for fp in args.asreview_files]
-
         plot_func(
             ax,
-            state_obj,
+            args.asreview_files,
             priors=args.priors,
             x_absolute=args.x_absolute,
             y_absolute=args.y_absolute,
             show_legend=show_legend,
-            legend_values=legend_values,
         )
 
         if args.output:

--- a/asreviewcontrib/insights/entrypoint.py
+++ b/asreviewcontrib/insights/entrypoint.py
@@ -190,23 +190,22 @@ class MetricsEntryPoint(BaseEntryPoint):
 
         output_dict = {}
         for asreview_file in args.asreview_files:
-            with open_state(asreview_file) as s:
-                if len(args.asreview_files) > 1:
-                    print(f"Calculating metrics for {asreview_file}")
-                stats = get_metrics(
-                    s,
-                    recall=args.recall,
-                    wss=args.wss,
-                    erf=args.erf,
-                    cm=args.cm,
-                    priors=args.priors,
-                    x_absolute=args.x_absolute,
-                    y_absolute=args.y_absolute,
-                    version=self.version,
-                )
-                output_dict[asreview_file] = stats
-                if not args.quiet:
-                    print_metrics(stats)
+            if len(args.asreview_files) > 1:
+                print(f"Calculating metrics for {asreview_file}")
+            stats = get_metrics(
+                asreview_file,
+                recall=args.recall,
+                wss=args.wss,
+                erf=args.erf,
+                cm=args.cm,
+                priors=args.priors,
+                x_absolute=args.x_absolute,
+                y_absolute=args.y_absolute,
+                version=self.version,
+            )
+            output_dict[asreview_file] = stats
+            if not args.quiet:
+                print_metrics(stats)
 
         if args.output:
             if len(args.asreview_files) == 1:

--- a/asreviewcontrib/insights/entrypoint.py
+++ b/asreviewcontrib/insights/entrypoint.py
@@ -43,24 +43,24 @@ class PlotEntryPoint(BaseEntryPoint):
         parser.add_argument(
             "--priors",
             action="store_true",
-            help="Include records used as prior knowledge " "in the plot.",
+            help="Include records used as prior knowledge in the plot.",
         )
         parser.add_argument(
             "--no-priors",
             dest="priors",
             action="store_false",
-            help="Exclude records used as prior knowledge " "in the plot. Default.",
+            help="Exclude records used as prior knowledge in the plot. Default.",
         )
         parser.set_defaults(priors=False)
         parser.add_argument(
             "--x_absolute",
             action="store_true",
-            help="Make use of absolute coordinates on" " the x-axis.",
+            help="Make use of absolute coordinates on the x-axis.",
         )
         parser.add_argument(
             "--y_absolute",
             action="store_true",
-            help="Make use of absolute coordinates on" " the y-axis.",
+            help="Make use of absolute coordinates on the y-axis.",
         )
         parser.add_argument(
             "-V",
@@ -156,24 +156,24 @@ class MetricsEntryPoint(BaseEntryPoint):
         parser.add_argument(
             "--priors",
             action="store_true",
-            help="Include records used as prior knowledge " "in the metrics.",
+            help="Include records used as prior knowledge in the metrics.",
         )
         parser.add_argument(
             "--no-priors",
             dest="priors",
             action="store_false",
-            help="Exclude records used as prior knowledge " "in the metrics. Default.",
+            help="Exclude records used as prior knowledge in the metrics. Default.",
         )
         parser.set_defaults(priors=False)
         parser.add_argument(
             "--x_absolute",
             action="store_true",
-            help="Make use of absolute coordinates on" " the x-axis.",
+            help="Make use of absolute coordinates on the x-axis.",
         )
         parser.add_argument(
             "--y_absolute",
             action="store_true",
-            help="Make use of absolute coordinates on" " the y-axis.",
+            help="Make use of absolute coordinates on the y-axis.",
         )
         parser.add_argument(
             "-o",
@@ -182,9 +182,7 @@ class MetricsEntryPoint(BaseEntryPoint):
             help="Save the metrics and results to a JSON file.",
         )
         parser.add_argument(
-            "--quiet",
-            action="store_true",
-            help="Suppress printed output of metrics."
+            "--quiet", action="store_true", help="Suppress printed output of metrics."
         )
         args = parser.parse_args(argv)
 

--- a/asreviewcontrib/insights/metrics.py
+++ b/asreviewcontrib/insights/metrics.py
@@ -79,7 +79,7 @@ def _erf(labels, intercept, x_absolute=False, y_absolute=False):
 
 
 def time_to_discovery(state_obj, priors=False):
-    labels = state_obj.get_dataset(["record_id", "label"], priors=priors)
+    labels = state_obj.get_results_table(columns=["record_id", "label"], priors=priors)
 
     return _time_to_discovery(labels["record_id"], labels["label"])
 

--- a/asreviewcontrib/insights/metrics.py
+++ b/asreviewcontrib/insights/metrics.py
@@ -11,7 +11,7 @@ from asreviewcontrib.insights.algorithms import _recall_values
 from asreviewcontrib.insights.algorithms import _tn_values
 from asreviewcontrib.insights.algorithms import _tp_values
 from asreviewcontrib.insights.algorithms import _wss_values
-from asreviewcontrib.insights.utils import _pad_simulation_labels
+from asreviewcontrib.insights.utils import get_simulation_labels
 
 
 def _slice_metric(x, y, intercept):
@@ -39,8 +39,8 @@ def _slice_metric(x, y, intercept):
     return y[i - 1]
 
 
-def recall(state_obj, intercept, priors=False, x_absolute=False, y_absolute=False):
-    labels = _pad_simulation_labels(state_obj, priors=priors)
+def recall(asreview_file, intercept, priors=False, x_absolute=False, y_absolute=False):
+    labels = get_simulation_labels(asreview_file=asreview_file, priors=priors)
 
     return _recall(labels, intercept, x_absolute=x_absolute, y_absolute=y_absolute)
 
@@ -54,8 +54,8 @@ def _recall(labels, intercept, x_absolute=False, y_absolute=False):
     return _slice_metric(x, y, intercept)
 
 
-def wss(state_obj, intercept, priors=False, x_absolute=False, y_absolute=False):
-    labels = _pad_simulation_labels(state_obj, priors=priors)
+def wss(asreview_file, intercept, priors=False, x_absolute=False, y_absolute=False):
+    labels = get_simulation_labels(asreview_file=asreview_file, priors=priors)
 
     return _wss(labels, intercept, x_absolute=x_absolute, y_absolute=y_absolute)
 
@@ -66,8 +66,8 @@ def _wss(labels, intercept, x_absolute=False, y_absolute=False):
     return _slice_metric(x, y, intercept)
 
 
-def erf(state_obj, intercept, priors=False, x_absolute=False, y_absolute=False):
-    labels = _pad_simulation_labels(state_obj, priors=priors)
+def erf(asreview_file, intercept, priors=False, x_absolute=False, y_absolute=False):
+    labels = get_simulation_labels(asreview_file=asreview_file, priors=priors)
 
     return _erf(labels, intercept, x_absolute=x_absolute, y_absolute=y_absolute)
 
@@ -78,10 +78,13 @@ def _erf(labels, intercept, x_absolute=False, y_absolute=False):
     return _slice_metric(x, y, intercept)
 
 
-def time_to_discovery(state_obj, priors=False):
-    labels = state_obj.get_results_table(columns=["record_id", "label"], priors=priors)
+def time_to_discovery(asreview_file, priors=False):
+    with asreview.open_state(asreview_file) as state_obj:
+        data = state_obj.get_results_table(
+            columns=["record_id", "label"], priors=priors
+        )
 
-    return _time_to_discovery(labels["record_id"], labels["label"])
+    return _time_to_discovery(data["record_id"], data["label"])
 
 
 def _time_to_discovery(record_ids, labels):
@@ -94,10 +97,11 @@ def _time_to_discovery(record_ids, labels):
     return list(zip(v_rel.tolist(), i_rel.tolist()))
 
 
-def average_time_to_discovery(state_obj, priors=False):
-    labels = state_obj.get_dataset(["record_id", "label"], priors=priors)
+def average_time_to_discovery(asreview_file, priors=False):
+    with asreview.open_state(asreview_file) as state_obj:
+        data = state_obj.get_dataset(["record_id", "label"], priors=priors)
 
-    td = _time_to_discovery(labels["record_id"], labels["label"])
+    td = _time_to_discovery(data["record_id"], data["label"])
     return _average_time_to_discovery(td)
 
 
@@ -105,8 +109,8 @@ def _average_time_to_discovery(td):
     return float(np.mean([v for i, v in td]))
 
 
-def tp(state_obj, intercept, priors=False, x_absolute=False):
-    labels = _pad_simulation_labels(state_obj, priors=priors)
+def tp(asreview_file, intercept, priors=False, x_absolute=False):
+    labels = get_simulation_labels(asreview_file=asreview_file, priors=priors)
 
     return _tp(labels, intercept, x_absolute=x_absolute)
 
@@ -117,8 +121,8 @@ def _tp(labels, intercept, x_absolute=False):
     return _slice_metric(x, y, intercept)
 
 
-def fp(state_obj, intercept, priors=False, x_absolute=False):
-    labels = _pad_simulation_labels(state_obj, priors=priors)
+def fp(asreview_file, intercept, priors=False, x_absolute=False):
+    labels = get_simulation_labels(asreview_file=asreview_file, priors=priors)
 
     return _fp(labels, intercept, x_absolute=x_absolute)
 
@@ -129,8 +133,8 @@ def _fp(labels, intercept, x_absolute=False):
     return _slice_metric(x, y, intercept)
 
 
-def tn(state_obj, intercept, priors=False, x_absolute=False):
-    labels = _pad_simulation_labels(state_obj, priors=priors)
+def tn(asreview_file, intercept, priors=False, x_absolute=False):
+    labels = get_simulation_labels(asreview_file=asreview_file, priors=priors)
 
     return _tn(labels, intercept, x_absolute=x_absolute)
 
@@ -141,8 +145,8 @@ def _tn(labels, intercept, x_absolute=False):
     return _slice_metric(x, y, intercept)
 
 
-def fn(state_obj, intercept, priors=False, x_absolute=False):
-    labels = _pad_simulation_labels(state_obj, priors=priors)
+def fn(asreview_file, intercept, priors=False, x_absolute=False):
+    labels = get_simulation_labels(asreview_file=asreview_file, priors=priors)
 
     return _fn(labels, intercept, x_absolute=x_absolute)
 
@@ -153,8 +157,8 @@ def _fn(labels, intercept, x_absolute=False):
     return _slice_metric(x, y, intercept)
 
 
-def tnr(state_obj, intercept, priors=False, x_absolute=False):
-    labels = _pad_simulation_labels(state_obj, priors=priors)
+def tnr(asreview_file, intercept, priors=False, x_absolute=False):
+    labels = get_simulation_labels(asreview_file=asreview_file, priors=priors)
 
     return _tnr(labels, intercept, x_absolute=x_absolute)
 
@@ -171,7 +175,7 @@ def _tnr(labels, intercept, x_absolute=False):
     return _slice_metric(x, y, intercept)
 
 
-def loss(state_obj, priors=False):
+def loss(asreview_file, priors=False):
     """Compute the loss for active learning problem.
 
     Computes the loss for active learning problem where all relevant records
@@ -182,13 +186,13 @@ def loss(state_obj, priors=False):
     Returns:
         float: The loss value.
     """
-    labels = _pad_simulation_labels(state_obj, priors=priors)
+    labels = get_simulation_labels(asreview_file=asreview_file, priors=priors)
 
     return _loss_value(labels)
 
 
 def get_metrics(
-    state_obj,
+    asreview_file,
     recall=None,
     wss=None,
     erf=None,
@@ -214,9 +218,9 @@ def get_metrics(
     erf = ensure_list_of_floats(erf, [0.10])
     cm = ensure_list_of_floats(cm, [0.1, 0.25, 0.5, 0.75, 0.9])
 
-    labels = _pad_simulation_labels(state_obj, priors=priors)
+    labels = get_simulation_labels(asreview_file, priors=priors)
 
-    td = time_to_discovery(state_obj)
+    td = time_to_discovery(asreview_file)
 
     recall_values = [
         _recall(labels, v, x_absolute=x_absolute, y_absolute=y_absolute) for v in recall

--- a/asreviewcontrib/insights/plot.py
+++ b/asreviewcontrib/insights/plot.py
@@ -1,14 +1,16 @@
+from pathlib import Path
+
 import numpy as np
 
 from asreviewcontrib.insights.algorithms import _erf_values
 from asreviewcontrib.insights.algorithms import _recall_values
 from asreviewcontrib.insights.algorithms import _wss_values
-from asreviewcontrib.insights.utils import _pad_simulation_labels
+from asreviewcontrib.insights.utils import get_simulation_labels
 
 
 def plot_recall(
     ax,
-    state_obj,
+    asreview_files,
     priors=False,
     x_absolute=False,
     y_absolute=False,
@@ -22,9 +24,8 @@ def plot_recall(
 
     Arguments
     ---------
-    state_obj: (list of) asreview.state.SQLiteState
-        State object from which to get the labels for the plot, or a list of
-        state objects.
+    asreview_files: str | Path | list[str | Path]
+        (List of) asreview files.
     priors: bool
         Include the prior in plot or not.
     x_absolute: bool
@@ -38,10 +39,11 @@ def plot_recall(
     show_optimal: bool
         Show the optimal recall in the plot.
     show_legend: bool
-        If state_obj contains multiple states, show a legend in the plot.
-    legend_values: list[str]
-        List of values to show in the legend if state_obj contains multiple
-        states and show_legend=True.
+        If `asreview_files` contains multiple files, show a legend in the plot.
+    legend_values: list[str] | None
+        List of values to show in the legend if `asreview_files` contains multiple
+        files and show_legend=True. If `show_legend=True` and this value is `None`,
+        then the names of the asreview files will be used as values in the legend.
     legend_kwargs: dict
         Dictionary of keyword arguments that are passed to the legend. See
         https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.legend.html
@@ -55,8 +57,13 @@ def plot_recall(
     The recall at T statistic is defined as the number of relevant records
     found after reviewing T records.
     """
-
-    labels = _pad_simulation_labels(state_obj, priors=priors)
+    if not isinstance(asreview_files, list):
+        asreview_files = [asreview_files]
+    labels = []
+    for asreview_file in asreview_files:
+        labels.append(get_simulation_labels(asreview_file=asreview_file, priors=priors))
+    if show_legend and legend_values is None:
+        legend_values = [Path(fp).stem for fp in asreview_files]
 
     return _plot_recall(
         ax,
@@ -73,7 +80,7 @@ def plot_recall(
 
 def plot_wss(
     ax,
-    state_obj,
+    asreview_files,
     priors=False,
     x_absolute=False,
     y_absolute=False,
@@ -85,9 +92,8 @@ def plot_wss(
 
     Arguments
     ---------
-    state_obj: (list of) asreview.state.SQLiteState
-        State object from which to get the labels for the plot, or a list of
-        state objects.
+    asreview_files: str | Path | list[str | Path]
+        (List of) asreview files.
     priors: bool
         Include the prior in plot or not.
     x_absolute: bool
@@ -97,10 +103,11 @@ def plot_wss(
         If True, the number of records reviewed less is on the y-axis.
         If False, the fraction of all records reviewed less is on the y-axis.
     show_legend: bool
-        If state_obj contains multiple states, show a legend in the plot.
-    legend_values: list[str]
-        List of values to show in the legend if state_obj contains multiple
-        states and show_legend=True.
+        If `asreview_files` contains multiple files, show a legend in the plot.
+    legend_values: list[str] | None
+        List of values to show in the legend if `asreview_files` contains multiple
+        files and show_legend=True. If `show_legend=True` and this value is `None`,
+        then the names of the asreview files will be used as values in the legend.
     legend_kwargs: dict
         Dictionary of keyword arguments that are passed to the legend. See
         https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.legend.html
@@ -141,8 +148,13 @@ def plot_wss(
     -------
     [Can we include the stats_explainer picture in the docs?]
     """
-
-    labels = _pad_simulation_labels(state_obj, priors=priors)
+    if not isinstance(asreview_files, list):
+        asreview_files = [asreview_files]
+    labels = []
+    for asreview_file in asreview_files:
+        labels.append(get_simulation_labels(asreview_file=asreview_file, priors=priors))
+    if show_legend and legend_values is None:
+        legend_values = [Path(fp).stem for fp in asreview_files]
 
     return _plot_wss(
         ax,
@@ -157,7 +169,7 @@ def plot_wss(
 
 def plot_erf(
     ax,
-    state_obj,
+    asreview_files,
     priors=False,
     x_absolute=False,
     y_absolute=False,
@@ -169,9 +181,8 @@ def plot_erf(
 
     Arguments
     ---------
-    state_obj: (list of) asreview.state.SQLiteState
-        State object from which to get the labels for the plot, or a list of
-        state objects.
+    asreview_files: str | Path | list[str | Path]
+        (List of) asreview files.
     priors: bool
         Include the prior in plot or not.
     x_absolute: bool
@@ -181,10 +192,11 @@ def plot_erf(
         If True, the number of included records found is on the y-axis.
         If False, the fraction of all included records found is on the y-axis.
     show_legend: bool
-        If state_obj contains multiple states, show a legend in the plot.
-    legend_values: list[str]
-        List of values to show in the legend if state_obj contains multiple
-        states and show_legend=True.
+        If `asreview_files` contains multiple files, show a legend in the plot.
+    legend_values: list[str] | None
+        List of values to show in the legend if `asreview_files` contains multiple
+        files and show_legend=True. If `show_legend=True` and this value is `None`,
+        then the names of the asreview files will be used as values in the legend.
     legend_kwargs: dict
         Dictionary of keyword arguments that are passed to the legend. See
         https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.legend.html
@@ -220,8 +232,13 @@ def plot_erf(
     -------
     [Can we include the stats_explainer picture in the docs?]
     """
-
-    labels = _pad_simulation_labels(state_obj, priors=priors)
+    if not isinstance(asreview_files, list):
+        asreview_files = [asreview_files]
+    labels = []
+    for asreview_file in asreview_files:
+        labels.append(get_simulation_labels(asreview_file=asreview_file, priors=priors))
+    if show_legend and legend_values is None:
+        legend_values = [Path(fp).stem for fp in asreview_files]
 
     return _plot_erf(
         ax,

--- a/asreviewcontrib/insights/utils.py
+++ b/asreviewcontrib/insights/utils.py
@@ -1,6 +1,6 @@
 import numpy as np
+from asreview import SQLiteState
 from asreview import open_state
-from asreview.state import SQLiteState
 
 
 def _pad_simulation_labels(state_obj, priors=False):
@@ -21,13 +21,15 @@ def _pad_simulation_labels(state_obj, priors=False):
     """
     if isinstance(state_obj, SQLiteState):
         # get the number of records
-        n_records = state_obj.n_records
+        n_records = len(state_obj.get_last_ranking_table())
 
         # get the labels
-        labels = state_obj.get_labels(priors=priors).to_list()
+        labels = state_obj.get_results_table(columns="label", priors=priors)[
+            "label"
+        ].to_list()
 
         if not priors:
-            n_used_records = n_records - state_obj.n_priors
+            n_used_records = n_records - len(state_obj.get_priors())
         else:
             n_used_records = n_records
 

--- a/asreviewcontrib/insights/utils.py
+++ b/asreviewcontrib/insights/utils.py
@@ -31,9 +31,9 @@ def get_simulation_labels(asreview_file, priors=False):
             "label"
         ].to_list()
         if priors:
-            n_priors_to_skip = len(state_obj.get_priors())
-        else:
             n_priors_to_skip = 0
+        else:
+            n_priors_to_skip = len(state_obj.get_priors())
 
     n_used_records = n_records - n_priors_to_skip
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,16 +8,15 @@ readme = "README.md"
 classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11"
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 license = {text = "Apache-2.0"}
 dependencies = ["numpy", "matplotlib", "asreview>=2"]
 dynamic = ["version"]
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 
 [project.urls]
 homepage = "https://asreview.ai"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11"
 ]
 license = {text = "Apache-2.0"}
-dependencies = ["numpy", "matplotlib", "asreview>=1,<2"]
+dependencies = ["numpy", "matplotlib", "asreview>=2"]
 dynamic = ["version"]
 requires-python = ">=3.7"
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import numpy as np
-from asreview import open_state
 from numpy import array_equal
 from numpy.testing import assert_almost_equal
 from numpy.testing import assert_raises
@@ -90,41 +89,31 @@ def test_time_to_disc():
 
 
 def test_metric_recall():
-    with open_state(
-        Path(TEST_ASREVIEW_FILES, "sim_van_de_schoot_2017_stop_if_min.asreview")
-    ) as s:
-        assert_almost_equal(recall(s, 0.25), 1)
+    fp = Path(TEST_ASREVIEW_FILES, "sim_van_de_schoot_2017_stop_if_min.asreview")
+    assert_almost_equal(recall(fp, 0.25), 1)
 
 
 def test_metric_priors():
-    with open_state(
-        Path(TEST_ASREVIEW_FILES, "sim_van_de_schoot_2017_stop_if_min.asreview")
-    ) as s:
-        r_priors = recall(s, 0.01, priors=True)
-        r_no_priors = recall(s, 0.01, priors=False)
+    fp = Path(TEST_ASREVIEW_FILES, "sim_van_de_schoot_2017_stop_if_min.asreview")
+    r_priors = recall(fp, 0.01, priors=True)
+    r_no_priors = recall(fp, 0.01, priors=False)
 
-        assert not array_equal(r_priors, r_no_priors)
+    assert not array_equal(r_priors, r_no_priors)
 
 
 def test_label_padding():
-    with open_state(
-        Path(TEST_ASREVIEW_FILES, "sim_van_de_schoot_2017_stop_if_min.asreview")
-    ) as s:
-        stop_if_min = get_metrics(s)
+    fp1 = Path(TEST_ASREVIEW_FILES, "sim_van_de_schoot_2017_stop_if_min.asreview")
+    stop_if_min = get_metrics(fp1)
 
-    with open_state(
-        Path(TEST_ASREVIEW_FILES, "sim_van_de_schoot_2017_stop_if_full.asreview")
-    ) as s:
-        stop_if_full = get_metrics(s)
+    fp2 = Path(TEST_ASREVIEW_FILES, "sim_van_de_schoot_2017_stop_if_full.asreview")
+    stop_if_full = get_metrics(fp2)
 
     assert stop_if_min == stop_if_full
 
 def test_loss():
-    with open_state(
-        Path(TEST_ASREVIEW_FILES, "sim_van_de_schoot_2017_stop_if_min.asreview")
-    ) as s:
-        loss_value = loss(s)
-        assert_almost_equal(loss_value, 0.011592855205548452)
+    fp = Path(TEST_ASREVIEW_FILES, "sim_van_de_schoot_2017_stop_if_min.asreview")
+    loss_value = loss(fp)
+    assert_almost_equal(loss_value, 0.011592855205548452)
 
 def test_loss_value_function(seed=None):
     test_cases = [
@@ -164,10 +153,8 @@ def test_single_value_formats():
     assert isinstance(_erf([1,1,0,0], 0.5), float)
 
 def test_get_metrics():
-    with open_state(
-        Path(TEST_ASREVIEW_FILES, "sim_van_de_schoot_2017_stop_if_min.asreview")
-    ) as s:
-        metrics = get_metrics(s, wss=[0.75, 0.85, 0.95], erf=[0.75, 0.85, 0.95])
+    fp = Path(TEST_ASREVIEW_FILES, "sim_van_de_schoot_2017_stop_if_min.asreview")
+    metrics = get_metrics(fp, wss=[0.75, 0.85, 0.95], erf=[0.75, 0.85, 0.95])
 
     wss_data = next(
         (item["value"] for item in metrics["data"]["items"] if item["id"] == "wss"),

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import matplotlib.pyplot as plt
-from asreview import open_state
 
 from asreviewcontrib.insights.plot import _plot_erf
 from asreviewcontrib.insights.plot import _plot_recall
@@ -9,7 +8,6 @@ from asreviewcontrib.insights.plot import _plot_wss
 from asreviewcontrib.insights.plot import plot_erf
 from asreviewcontrib.insights.plot import plot_recall
 from asreviewcontrib.insights.plot import plot_wss
-from asreviewcontrib.insights.utils import _iter_states
 
 TEST_ASREVIEW_FILES = Path(Path(__file__).parent, "asreview_files")
 TEST_FIGURES = Path("figures")
@@ -43,15 +41,12 @@ def test_plot_recall_small_data():
 
 
 def test_plot_recall():
-    with open_state(
-        Path(TEST_ASREVIEW_FILES, "sim_van_de_schoot_2017_stop_if_min.asreview")
-    ) as s:
-        fig, ax = plt.subplots()
-        plot_recall(ax, s)
-
-        fig.savefig(
-            Path(TEST_FIGURES, "tests_recall_sim_van_de_schoot_2017_stop_if_min.png")
-        )
+    fp = Path(TEST_ASREVIEW_FILES, "sim_van_de_schoot_2017_stop_if_min.asreview")
+    fig, ax = plt.subplots()
+    plot_recall(ax, fp)
+    fig.savefig(
+        Path(TEST_FIGURES, "tests_recall_sim_van_de_schoot_2017_stop_if_min.png")
+    )
 
 
 def test_plot_multiple_recall():
@@ -59,52 +54,46 @@ def test_plot_multiple_recall():
         Path(TEST_ASREVIEW_FILES, "sim_van_de_schoot_2017_stop_if_min.asreview"),
         Path(TEST_ASREVIEW_FILES, "sim_van_de_schoot_2017_logistic.asreview"),
     ]
-
     fig, ax = plt.subplots()
-    states = _iter_states(fps)
-    legend_values = [fp.stem for fp in fps]
-    plot_recall(ax, states, legend_values=legend_values)
-
+    plot_recall(ax, fps)
     fig.savefig(Path(TEST_FIGURES, "tests_multiple_recall_sim_van_de_schoot_2017.png"))
 
 
 def test_plot_wss():
-    with open_state(
-        Path(TEST_ASREVIEW_FILES, "sim_van_de_schoot_2017_stop_if_min.asreview")
-    ) as s:
-        fig, ax = plt.subplots()
-        plot_wss(ax, s)
-        fig.savefig(
-            Path(
-                TEST_FIGURES, "tests_wss_default_sim_van_de_schoot_2017_stop_if_min.png"
-            )
+    fp = Path(TEST_ASREVIEW_FILES, "sim_van_de_schoot_2017_stop_if_min.asreview")
+    fig, ax = plt.subplots()
+    plot_wss(ax, fp)
+    fig.savefig(
+        Path(
+            TEST_FIGURES, "tests_wss_default_sim_van_de_schoot_2017_stop_if_min.png"
         )
+    )
 
-        fig, ax = plt.subplots()
-        plot_wss(ax, s)
-        fig.savefig(
-            Path(
-                TEST_FIGURES, "tests_wss_default_sim_van_de_schoot_2017_stop_if_min.png"
-            )
+    fig, ax = plt.subplots()
+    plot_wss(ax, fp)
+    fig.savefig(
+        Path(
+            TEST_FIGURES, "tests_wss_default_sim_van_de_schoot_2017_stop_if_min.png"
         )
+    )
 
-        fig, ax = plt.subplots()
-        plot_wss(ax, s, x_absolute=True)
-        fig.savefig(
-            Path(TEST_FIGURES, "tests_wss_xabs_sim_van_de_schoot_2017_stop_if_min.png")
-        )
+    fig, ax = plt.subplots()
+    plot_wss(ax, fp, x_absolute=True)
+    fig.savefig(
+        Path(TEST_FIGURES, "tests_wss_xabs_sim_van_de_schoot_2017_stop_if_min.png")
+    )
 
-        fig, ax = plt.subplots()
-        plot_wss(ax, s, y_absolute=True)
-        fig.savefig(
-            Path(TEST_FIGURES, "tests_wss_yabs_sim_van_de_schoot_2017_stop_if_min.png")
-        )
+    fig, ax = plt.subplots()
+    plot_wss(ax, fp, y_absolute=True)
+    fig.savefig(
+        Path(TEST_FIGURES, "tests_wss_yabs_sim_van_de_schoot_2017_stop_if_min.png")
+    )
 
-        fig, ax = plt.subplots()
-        plot_wss(ax, s, x_absolute=True, y_absolute=True)
-        fig.savefig(
-            Path(TEST_FIGURES, "tests_wss_xyabs_sim_van_de_schoot_2017_stop_if_min.png")
-        )
+    fig, ax = plt.subplots()
+    plot_wss(ax, fp, x_absolute=True, y_absolute=True)
+    fig.savefig(
+        Path(TEST_FIGURES, "tests_wss_xyabs_sim_van_de_schoot_2017_stop_if_min.png")
+    )
 
 
 def test_plot_multiple_wss():
@@ -114,50 +103,46 @@ def test_plot_multiple_wss():
     ]
 
     fig, ax = plt.subplots()
-    states = _iter_states(fps)
-    legend_values = [fp.stem for fp in fps]
-    plot_wss(ax, states, legend_values=legend_values)
+    plot_wss(ax, fps)
 
     fig.savefig(Path(TEST_FIGURES, "tests_multiple_wss_sim_van_de_schoot_2017.png"))
 
 
 def test_plot_erf():
-    with open_state(
-        Path(TEST_ASREVIEW_FILES, "sim_van_de_schoot_2017_stop_if_min.asreview")
-    ) as s:
-        fig, ax = plt.subplots()
-        plot_erf(ax, s)
-        fig.savefig(
-            Path(
-                TEST_FIGURES, "tests_erf_default_sim_van_de_schoot_2017_stop_if_min.png"
-            )
+    fp = Path(TEST_ASREVIEW_FILES, "sim_van_de_schoot_2017_stop_if_min.asreview")
+    fig, ax = plt.subplots()
+    plot_erf(ax, fp)
+    fig.savefig(
+        Path(
+            TEST_FIGURES, "tests_erf_default_sim_van_de_schoot_2017_stop_if_min.png"
         )
+    )
 
-        fig, ax = plt.subplots()
-        plot_erf(ax, s)
-        fig.savefig(
-            Path(
-                TEST_FIGURES, "tests_erf_default_sim_van_de_schoot_2017_stop_if_min.png"
-            )
+    fig, ax = plt.subplots()
+    plot_erf(ax, fp)
+    fig.savefig(
+        Path(
+            TEST_FIGURES, "tests_erf_default_sim_van_de_schoot_2017_stop_if_min.png"
         )
+    )
 
-        fig, ax = plt.subplots()
-        plot_erf(ax, s, x_absolute=True)
-        fig.savefig(
-            Path(TEST_FIGURES, "tests_erf_xabs_sim_van_de_schoot_2017_stop_if_min.png")
-        )
+    fig, ax = plt.subplots()
+    plot_erf(ax, fp, x_absolute=True)
+    fig.savefig(
+        Path(TEST_FIGURES, "tests_erf_xabs_sim_van_de_schoot_2017_stop_if_min.png")
+    )
 
-        fig, ax = plt.subplots()
-        plot_erf(ax, s, y_absolute=True)
-        fig.savefig(
-            Path(TEST_FIGURES, "tests_erf_yabs_sim_van_de_schoot_2017_stop_if_min.png")
-        )
+    fig, ax = plt.subplots()
+    plot_erf(ax, fp, y_absolute=True)
+    fig.savefig(
+        Path(TEST_FIGURES, "tests_erf_yabs_sim_van_de_schoot_2017_stop_if_min.png")
+    )
 
-        fig, ax = plt.subplots()
-        plot_erf(ax, s, x_absolute=True, y_absolute=True)
-        fig.savefig(
-            Path(TEST_FIGURES, "tests_erf_xyabs_sim_van_de_schoot_2017_stop_if_min.png")
-        )
+    fig, ax = plt.subplots()
+    plot_erf(ax, fp, x_absolute=True, y_absolute=True)
+    fig.savefig(
+        Path(TEST_FIGURES, "tests_erf_xyabs_sim_van_de_schoot_2017_stop_if_min.png")
+    )
 
 
 def test_plot_multiple_erf():
@@ -167,9 +152,7 @@ def test_plot_multiple_erf():
     ]
 
     fig, ax = plt.subplots()
-    states = _iter_states(fps)
-    legend_values = [fp.stem for fp in fps]
-    plot_erf(ax, states, legend_values=legend_values)
+    plot_erf(ax, fps)
 
     fig.savefig(Path(TEST_FIGURES, "tests_multiple_erf_sim_van_de_schoot_2017.png"))
 
@@ -178,7 +161,6 @@ def test_plot_with_priors():
     fp = Path(TEST_ASREVIEW_FILES, "sim_van_de_schoot_2017_stop_if_min.asreview")
 
     fig, ax = plt.subplots()
-    with open_state(fp) as s:
-        plot_recall(ax, s, priors=True)
+    plot_recall(ax, fp, priors=True)
 
     fig.savefig(Path(TEST_FIGURES, "tests_priors_recall_sim_van_de_schoot_2017.png"))


### PR DESCRIPTION
This pull request makes asreview-insights ready for asreview version 2. It involves breaking changes to the Python API. The plotting and metrics functions now take paths to asreview files as input instead of state objects. This is necessary with asreview version 2, because the state objects does not contain the total number of records in the input dataset, which we need to pad the simulation labels. But this also seems like a improvement to the usability of the Python API. The underlying functions that take the actual labels as input remain unchanged.